### PR TITLE
Fix constructor call example in README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ composer require assegaiphp/forms
    ```php
    use Assegai\Forms\Form;
 
-   $form = new Form('contact_form', 'POST', '/submit');
+   $form = new Form(null, 'POST', '/submit');
    ```
 
 2. **Add Form Fields:**


### PR DESCRIPTION
This pull request updates the usage example in the `README.md` to reflect a change in how the `Form` class is instantiated. The form name parameter is now set to `null` instead of `'contact_form'`. 

* Updated the example instantiation of the `Form` class in the `README.md` to use `null` for the form name parameter, likely to reflect a new default or recommended usage.